### PR TITLE
Make it possible for chords to store key/value pairs

### DIFF
--- a/bin/ocarina.py
+++ b/bin/ocarina.py
@@ -32,7 +32,7 @@ def setup_db():
                                        currentDirectory, '../results.db'))
     else:
         databaseFile = databaseFromConf
-    db = core.database.getDatabase(databaseFile)
+    db = core.database.getInstance(databaseFile, createModel = True)
     return db
 
 

--- a/core/chords.py
+++ b/core/chords.py
@@ -12,7 +12,7 @@ from status import Status
 from virtualenvironment import IsolatedVirtualEnvironment
 
 import database
-db = database.getDatabase()
+db = database.getInstance()
 
 Chord = namedtuple('Chord', ['path', 'name'])
 

--- a/core/database.py
+++ b/core/database.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 import sqlite3
 
@@ -6,25 +7,26 @@ logging = log.getLogger()
 
 from model import model
 
-databaseInstance = None
+databaseInstance = {}
 
 
-def getDatabase(filename='results.db'):
+def getInstance(filename='results.db', createModel = False):
     global databaseInstance
-    if databaseInstance is not None:
-        return databaseInstance
-    databaseInstance = Database(filename)
-    return databaseInstance
+    if databaseInstance.get(filename) is not None:
+        return databaseInstance.get(filename)
+    databaseInstance[filename]= Database(filename, createModel)
+    return databaseInstance[filename]
 
 
 class Database(object):
 
-    def __init__(self, filename):
+    def __init__(self, filename, createModel = False):
         try:
             logging.debug('Attempting to open database %s', filename)
             self.conn = sqlite3.connect(filename)
             self.cursor = self.conn.cursor()
-            self._setupNecessary()
+            if createModel:
+                self._setupNecessary()
         except Exception as e:
             logging.critical('Could not open database %s: %s', filename, e)
             sys.exit(3)
@@ -52,6 +54,28 @@ class Database(object):
         except Exception as e:
             logging.critical('Could not execute query: %s', e)
             sys.exit( 7 )
+
+    def _getChord(self):
+        """Get the module name of the chord making the database call"""
+        frm = inspect.stack()[3]
+        mod = inspect.getmodule(frm[0])
+        return mod.__name__
+
+    def _constructKeyName(self, key):
+        return '.'.join([self._getChord(), key])
+
+    def get(self, key):
+        sql = '''SELECT value FROM state WHERE key = ?'''
+        return self._executeQuery(sql, [self._constructKeyName(key)], return_result = True)
+
+    def set(self, key, value):
+        sql = '''INSERT OR REPLACE INTO state ("key", "value") VALUES (?, ?)'''
+        self._executeQuery(
+            sql,
+            [self._constructKeyName(key), value],
+            return_result = False,
+            commit = True
+        )
 
     def recordExecution(self, start_time, chord_name, execution_time, status,
                         output):

--- a/core/model.py
+++ b/core/model.py
@@ -2,5 +2,8 @@ model = {
     'execution': '''CREATE TABLE IF NOT EXISTS execution (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     time_start INTEGER, chord_name TEXT, execution_time FLOAT,
-    status INTEGER, output BLOB )'''
+    status INTEGER, output BLOB )''',
+    'state': '''CREATE TABLE IF NOT EXISTS state (
+    key TEXT NOT NULL UNIQUE,
+    value BLOB NOT NULL)'''
 }


### PR DESCRIPTION
Make a key/value storage accessible to the chords through a simple API:

    import database
    global db
    db = database.getInstance()

    previousExternalIp = db.get("external_ip_address")
    print "Previous external IP was %s" % previousExternalIp

    externalIp = resolveExternalIp()
    if externalIp:
        db.set("external_ip_address", externalIp)
        print "New external IP is %s" % externalIp

The keys are namespaced by module name, which means multiple chords can use the same key without collisions.