### PR TITLE
Make it possible to share key/value between chords

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -63,12 +63,13 @@ class Database(object):
         mod = inspect.getmodule(frm[0])
         return mod.__name__
 
-    def _constructKeyName(self, key):
-        return '.'.join([self._getChord(), key])
+    def _constructKeyName(self, key, private = True):
+        prefix = self._getChord() + "." if private else ""
+        return "%s%s" % (prefix, key)
 
-    def get(self, key):
+    def get(self, key, private = True):
         sql = '''SELECT value FROM state WHERE key = ?'''
-        result = self._executeQuery(sql, [self._constructKeyName(key)], return_result = True)
+        result = self._executeQuery(sql, [self._constructKeyName(key, private)], return_result = True)
         if result:
             result = str(result[0][0])
             try:
@@ -77,12 +78,12 @@ class Database(object):
                 return result
         return None
 
-    def set(self, key, value):
+    def set(self, key, value, private = True):
         value = pickle.dumps(value)
         sql = '''INSERT OR REPLACE INTO state ("key", "value") VALUES (?, ?)'''
         self._executeQuery(
             sql,
-            [self._constructKeyName(key), value],
+            [self._constructKeyName(key, private), value],
             return_result = False,
             commit = True
         )

--- a/tests/TestDatabase.py
+++ b/tests/TestDatabase.py
@@ -11,22 +11,39 @@ import database
 
 class TestDatabase(unittest.TestCase):
 
-	db = None
+    db = None
 
-	def setUp(self):
-		self.db = database.getInstance(":memory:", True)
+    def setUp(self):
+        self.db = database.getInstance(":memory:", True)
 
-	def testSetKeyValuePair(self):
-		self.db.set("some_key", "some_value")
-		self.assertEquals("some_value", self.db.get("some_key"))
+    def assertKeyExists(self, key):
+        sql = '''SELECT COUNT(value) FROM state WHERE key = ?'''
+        result = int(self.db._executeQuery(
+            sql,
+            [key],
+            return_result = True
+            )[0][0])
+        self.assertEquals(result, 1)
 
-	def testGetNonExistingKeyValuePair(self):
-		self.assertEquals(None, self.db.get("some_key"))
+    def testSetKeyValuePair(self):
+        self.db.set("some_key", "some_value")
+        self.assertEquals("some_value", self.db.get("some_key"))
 
-	def testSetDictionary(self):
-		self.db.set("some_key", { "a" : 1, "b" : 2})
-		retrievedDict = self.db.get("some_key")
-		self.assertEquals({ "a" : 1, "b" : 2}, retrievedDict)
+    def testGetNonExistingKeyValuePair(self):
+        self.assertEquals(None, self.db.get("some_key"))
+
+    def testSetDictionary(self):
+        self.db.set("some_key", { "a" : 1, "b" : 2})
+        retrievedDict = self.db.get("some_key")
+        self.assertEquals({ "a" : 1, "b" : 2}, retrievedDict)
+
+    def testSetPublicKeyValuePair(self):
+        self.db.set("some_key", "some_value", private = False)
+        self.assertKeyExists("some_key")
+
+    def testSetPrivateKeyValuePair(self):
+        self.db.set("some_key", "some_value", private = True)
+        self.assertKeyExists("__main__.some_key")
 
 def main():
     unittest.main()


### PR DESCRIPTION
Key/value can optionally be shared between chords, by setting `private` to ´False´ (default is ´True´):

    self.db.set("some_key", "some_value", private = False)