### PR TITLE
Make shouldRun mandatory

### DIFF
--- a/core/chords.py
+++ b/core/chords.py
@@ -56,9 +56,9 @@ def shouldRun(module, now, logging):
          logging.debug('shouldRun() returned %s', run)
     else:
          logging.debug(
-             'No shouldRun() found on %s, assuming it should run always',
+             'No shouldRun() found on %s, assuming it is a library',
              module.__name__)
-         run = True 
+         run = False 
     return run
 
 def requiresVirtualEnv(module):

--- a/tests/TestShouldRun.py
+++ b/tests/TestShouldRun.py
@@ -14,7 +14,7 @@ class TestShouldRun(unittest.TestCase):
 
 	def testModuleWithoutShouldRunMethod(self):
 		now = Now(tweak = "2015-01-01 12:00:00")
-		self.assertTrue(chords.shouldRun(
+		self.assertFalse(chords.shouldRun(
 			mockings.createModule(
 				"WithoutShouldRunMethod",
 				"def main():\n\tpass"


### PR DESCRIPTION
At the moment it is not possible to have library files along with your chords.

By making the absence of `shouldRun´ treated as "do not run", that will be possible.